### PR TITLE
allow adding additional permanent codes to an organization with optional name

### DIFF
--- a/openspec/changes/archive/2026-06-14-allow-additional-permanent-code/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-14-allow-additional-permanent-code/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-14

--- a/openspec/changes/archive/2026-06-14-allow-additional-permanent-code/design.md
+++ b/openspec/changes/archive/2026-06-14-allow-additional-permanent-code/design.md
@@ -1,0 +1,40 @@
+## Context
+
+Organization permanent codes are managed from `/organizations/manage-organizations/` via `manager_permanent_code_action_view` (`@manager_required`), which delegates to three service functions in `re_sharing/resources/services_permanent_code.py`: create, invalidate, renew.
+
+Today, creating a code is blocked in two independent places when an active code exists:
+
+1. **Service guard** — `create_permanent_code_for_organization` queries for an active code (`validity_start <= now` and `validity_end` null-or-future) and raises `ValidationError` if one is found.
+2. **UI gate** — `manager_list_organizations.html` only renders the "Create Code" action inside the `{% if not organization.active_codes %}` branch; when codes exist it shows only Invalidate/Renew.
+
+The `PermanentCode` model has no uniqueness constraint on organization, and the `renew` flow already produces two concurrently-active codes (old code valid for one more week). So multiple active codes per organization is an already-supported, already-handled state — the create block is artificial.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Let a manager add an additional permanent code while existing codes stay valid.
+- Keep the existing `@manager_required` permission gate.
+- Warn the manager in the confirm dialog when an active code already exists.
+
+**Non-Goals:**
+- No change to invalidate or renew behavior.
+- No model or migration changes.
+- No change to which accesses are assigned (`[1, 2, 8]`) or the code-generation algorithm.
+- No new permission tier (staff/admin-only path was considered and rejected).
+
+## Decisions
+
+**Remove the service-level active-code guard rather than add a `force` flag.**
+The guard at `services_permanent_code.py:46-58` is deleted so `create_permanent_code_for_organization` always creates. A `force=True` opt-in parameter was considered but rejected: the only caller is the create action, and the desired behavior is now "always allow," so a flag would be dead configuration. The active-code lookup (and its `Q`/`timezone` usage, if otherwise unused) is removed with it.
+
+**Always render "Create Code" in the template, with a context-aware confirm.**
+Move the create action out of the `{% if not organization.active_codes %}` exclusivity so it shows alongside Invalidate/Renew. When `organization.active_codes` is truthy, the `hx-confirm` text warns the organization already has an active code; otherwise it keeps the current "Create a new permanent code…" prompt.
+
+**Keep `@manager_required`.**
+Per the explore decision, any manager who can create/renew today can add an additional code. No new gate.
+
+## Risks / Trade-offs
+
+- **Accidental duplicate codes** → The warning confirm dialog when active codes exist makes the "additional" nature explicit, distinguishing it from Renew.
+- **A second create email fires** → Consistent with the existing create flow (`send_permanent_code_created_email`); acceptable and expected.
+- **Name collision** → New code reuses the `"Permanent code for {org}"` name; `name` is not unique, so this is harmless.

--- a/openspec/changes/archive/2026-06-14-allow-additional-permanent-code/proposal.md
+++ b/openspec/changes/archive/2026-06-14-allow-additional-permanent-code/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+Managers can create a permanent access code for an organization, but only when the organization has no active code — the service raises a `ValidationError` and the UI hides the "Create Code" action once a code exists. Managers sometimes need a second, parallel permanent code (e.g. handing a distinct code to a different group while the original stays valid). The data model already permits multiple active codes per organization, so this restriction is an artificial block rather than a constraint.
+
+## What Changes
+
+- Allow creating an additional permanent code for an organization at `/organizations/manage-organizations/` even when an active code already exists.
+- Remove the service-level guard in `create_permanent_code_for_organization` that raises `ValidationError` when an active code is present.
+- Always show the "Create Code" action in the organization manager list; when active codes already exist, the confirm dialog warns that the organization already has an active code before proceeding.
+- Keep the `@manager_required` permission gate unchanged — the same managers who can create/renew today can add an additional code.
+- Update tests: the existing "fails when an active code exists" test flips to assert the additional code is created; add coverage for the create action being available alongside active codes.
+- No model or migration changes — the data model already supports multiple active codes per organization.
+
+## Capabilities
+
+### New Capabilities
+- `organization-permanent-codes`: Manager-facing management of organization permanent access codes — creating, adding additional, invalidating, and renewing codes from the organization manager list.
+
+### Modified Capabilities
+<!-- No existing specs in openspec/specs/; this capability is introduced new. -->
+
+## Impact
+
+- `re_sharing/resources/services_permanent_code.py` — remove the active-code guard in `create_permanent_code_for_organization`.
+- `re_sharing/templates/organizations/manager_list_organizations.html` — always render the "Create Code" action; add a warning confirm when active codes exist.
+- `re_sharing/organizations/tests/test_views_permanent_code.py` — update `test_create_permanent_code_fails_when_active_code_exists` and add coverage for the create action with existing codes.
+- No database migration. `@manager_required` gate and the invalidate/renew flows are unchanged.

--- a/openspec/changes/archive/2026-06-14-allow-additional-permanent-code/specs/organization-permanent-codes/spec.md
+++ b/openspec/changes/archive/2026-06-14-allow-additional-permanent-code/specs/organization-permanent-codes/spec.md
@@ -1,0 +1,47 @@
+## ADDED Requirements
+
+### Requirement: Manager can create an additional permanent code for an organization
+
+The system SHALL allow a manager to create a permanent access code for an organization at `/organizations/manage-organizations/` regardless of whether the organization already has one or more active permanent codes. Creating a code MUST NOT invalidate or modify any existing code; the new code is created as an additional, independently valid code.
+
+#### Scenario: Create the first permanent code
+
+- **WHEN** a manager triggers the create action for an organization that has no active permanent code
+- **THEN** the system creates a new permanent code for the organization
+- **AND** the manager organization list reflects the new code
+
+#### Scenario: Create an additional code when an active code already exists
+
+- **WHEN** a manager triggers the create action for an organization that already has one or more active permanent codes
+- **THEN** the system creates a new permanent code without raising a validation error
+- **AND** the existing active codes remain valid and unchanged
+
+#### Scenario: Create action is available in the UI when active codes exist
+
+- **WHEN** a manager views an organization that has one or more active permanent codes
+- **THEN** the "Create Code" action is available
+- **AND** the create dialog warns that the organization already has an active code before proceeding
+
+#### Scenario: Manager names the new code
+
+- **WHEN** a manager provides a name while creating a permanent code
+- **THEN** the new code is created with that name
+
+#### Scenario: Manager leaves the name blank
+
+- **WHEN** a manager creates a permanent code without providing a name (or with only whitespace)
+- **THEN** the new code is created with a default name derived from the organization name
+
+### Requirement: Permanent code management is restricted to managers
+
+The system SHALL restrict creating, adding additional, invalidating, and renewing organization permanent codes to authenticated managers. Requests from users without a manager role MUST be denied.
+
+#### Scenario: Non-manager is denied
+
+- **WHEN** a user without a manager role attempts a permanent code action
+- **THEN** the system denies the request with a forbidden response
+
+#### Scenario: Anonymous user is redirected
+
+- **WHEN** an anonymous user attempts a permanent code action
+- **THEN** the system redirects the user to the login page

--- a/openspec/changes/archive/2026-06-14-allow-additional-permanent-code/tasks.md
+++ b/openspec/changes/archive/2026-06-14-allow-additional-permanent-code/tasks.md
@@ -1,0 +1,28 @@
+## 1. Tests (red)
+
+- [x] 1.1 Rewrite `test_create_permanent_code_fails_when_active_code_exists` in `re_sharing/organizations/tests/test_views_permanent_code.py` to assert that creating with an active code present succeeds (HTTP 200) and results in a second `PermanentCode` for the organization; rename it accordingly (e.g. `test_create_additional_permanent_code_when_active_code_exists`)
+- [x] 1.2 Add a test asserting the "Create Code" action is present in the returned partial even when an active code exists
+- [x] 1.3 Run the new tests and confirm they fail (red)
+
+## 2. Service change (green)
+
+- [x] 2.1 Remove the active-code guard (the `existing_code` lookup and `ValidationError` raise) from `create_permanent_code_for_organization` in `re_sharing/resources/services_permanent_code.py`
+- [x] 2.2 Remove now-unused imports (`Q`, and `timezone` if no longer referenced) if applicable
+
+## 3. UI change
+
+- [x] 3.1 In `re_sharing/templates/organizations/manager_list_organizations.html`, move the "Create Code" action out of the `{% if not organization.active_codes %}` exclusivity so it always renders
+- [x] 3.2 Make the create action's `hx-confirm` context-aware: warn that the organization already has an active code when `organization.active_codes` is truthy, otherwise keep the existing prompt
+
+## 4. Custom name for new code
+
+- [x] 4.1 Add an optional `name` parameter to `create_permanent_code_for_organization`; use it when non-blank, otherwise fall back to the default derived name
+- [x] 4.2 Pass the posted `name` through in `manager_permanent_code_action_view`
+- [x] 4.3 Replace the "Create Code" confirm with a modal containing an optional name input (and the active-code warning); submit via HTMX with the name
+- [x] 4.4 Add service- and view-level tests for custom name and blank-name default
+
+## 5. Verify
+
+- [x] 5.1 Run the permanent-code view tests and confirm they pass (green)
+- [x] 5.2 Run the full test suite and ensure no regressions
+- [x] 5.3 Run pre-commit (Ruff, djLint) on the changed files

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,19 @@
+schema: spec-driven
+# Project context (optional)
+# This is shown to AI when creating artifacts.
+# Add your tech stack, conventions, style guides, domain knowledge, etc.
+
+context: |
+  Tech stack: Django, Postgres, htmx
+  We use conventional commits
+  Domain: Booking software
+
+
+rules:
+  proposal:
+    - follow the hacksoft django stylguide: https://github.com/HackSoftware/Django-Styleguide
+    - Keep proposals under 500 words
+    - Always include a "Non-goals" section
+  tasks:
+    - Break tasks into chunks of max 2 hours
+    - always work with test-drive (red green)

--- a/openspec/specs/organization-permanent-codes/spec.md
+++ b/openspec/specs/organization-permanent-codes/spec.md
@@ -1,0 +1,53 @@
+# organization-permanent-codes Specification
+
+## Purpose
+
+Manage permanent access codes for organizations. Managers can create, name, add additional, invalidate, and renew permanent codes that grant organization-level access. An organization may have multiple independently valid permanent codes at the same time.
+
+## Requirements
+
+### Requirement: Manager can create an additional permanent code for an organization
+
+The system SHALL allow a manager to create a permanent access code for an organization at `/organizations/manage-organizations/` regardless of whether the organization already has one or more active permanent codes. Creating a code MUST NOT invalidate or modify any existing code; the new code is created as an additional, independently valid code.
+
+#### Scenario: Create the first permanent code
+
+- **WHEN** a manager triggers the create action for an organization that has no active permanent code
+- **THEN** the system creates a new permanent code for the organization
+- **AND** the manager organization list reflects the new code
+
+#### Scenario: Create an additional code when an active code already exists
+
+- **WHEN** a manager triggers the create action for an organization that already has one or more active permanent codes
+- **THEN** the system creates a new permanent code without raising a validation error
+- **AND** the existing active codes remain valid and unchanged
+
+#### Scenario: Create action is available in the UI when active codes exist
+
+- **WHEN** a manager views an organization that has one or more active permanent codes
+- **THEN** the "Create Code" action is available
+- **AND** the create dialog warns that the organization already has an active code before proceeding
+
+#### Scenario: Manager names the new code
+
+- **WHEN** a manager provides a name while creating a permanent code
+- **THEN** the new code is created with that name
+
+#### Scenario: Manager leaves the name blank
+
+- **WHEN** a manager creates a permanent code without providing a name (or with only whitespace)
+- **THEN** the new code is created with a default name derived from the organization name
+
+### Requirement: Permanent code management is restricted to managers
+
+The system SHALL restrict creating, adding additional, invalidating, and renewing organization permanent codes to authenticated managers. Requests from users without a manager role MUST be denied.
+
+#### Scenario: Non-manager is denied
+
+- **WHEN** a user without a manager role attempts a permanent code action
+- **THEN** the system denies the request with a forbidden response
+
+#### Scenario: Anonymous user is redirected
+
+- **WHEN** an anonymous user attempts a permanent code action
+- **THEN** the system redirects the user to the login page

--- a/re_sharing/organizations/tests/test_views_permanent_code.py
+++ b/re_sharing/organizations/tests/test_views_permanent_code.py
@@ -65,13 +65,19 @@ class TestManagerPermanentCodeActionView(TestCase):
         mock_email.enqueue.assert_called_once()
 
     @patch("re_sharing.resources.services_permanent_code._generate_permanent_code")
-    def test_create_permanent_code_fails_when_active_code_exists(
-        self, mock_generate_code
+    @patch(
+        "re_sharing.resources.services_permanent_code.send_permanent_code_created_email"
+    )
+    def test_create_additional_permanent_code_when_active_code_exists(
+        self, mock_email, mock_generate_code
     ):
-        """Test that creating a code fails when an active code exists."""
-        # Create existing code
-        PermanentCodeFactory(
+        """Test that an additional code can be created when an active code exists."""
+        mock_generate_code.return_value = "654321"
+
+        # Create existing active code
+        existing_code = PermanentCodeFactory(
             organization=self.organization,
+            code="111111",
             validity_start=timezone.now() - timedelta(days=1),
             validity_end=None,
             accesses=[self.access1],
@@ -82,8 +88,65 @@ class TestManagerPermanentCodeActionView(TestCase):
             self.url, data={"action": "create"}, headers={"hx-request": "true"}
         )
 
-        # Should return error
-        assert response.status_code == HTTPStatus.BAD_REQUEST
+        # Should succeed and create a second, independent code
+        assert response.status_code == HTTPStatus.OK
+        assert (
+            PermanentCode.objects.filter(organization=self.organization).count() == 2  # noqa: PLR2004
+        )
+
+        # Existing code remains valid and unchanged
+        existing_code.refresh_from_db()
+        assert existing_code.validity_end is None
+        assert existing_code.code == "111111"
+
+    @patch("re_sharing.resources.services_permanent_code._generate_permanent_code")
+    @patch(
+        "re_sharing.resources.services_permanent_code.send_permanent_code_created_email"
+    )
+    def test_create_permanent_code_with_custom_name(
+        self, mock_email, mock_generate_code
+    ):
+        """Test that a posted name is applied to the new code."""
+        mock_generate_code.return_value = "246810"
+
+        self.client.force_login(self.manager_user)
+        response = self.client.post(
+            self.url,
+            data={"action": "create", "name": "Reception key"},
+            headers={"hx-request": "true"},
+        )
+
+        assert response.status_code == HTTPStatus.OK
+
+        permanent_code = PermanentCode.objects.get(organization=self.organization)
+        assert permanent_code.name == "Reception key"
+
+    def test_create_code_action_available_when_active_code_exists(self):
+        """Test that the Create Code action is shown even when a code is active."""
+        permanent_code = PermanentCodeFactory(
+            organization=self.organization,
+            code="123456",
+            validity_start=timezone.now() - timedelta(days=1),
+            validity_end=None,
+            accesses=[self.access1],
+        )
+
+        self.client.force_login(self.manager_user)
+        # Invalidate with a future date so the code remains in the active list
+        future_date = timezone.now() + timedelta(days=7)
+        response = self.client.post(
+            self.url,
+            data={
+                "action": "invalidate",
+                "permanent_code_id": permanent_code.id,
+                "validity_end": future_date.strftime("%Y-%m-%dT%H:%M"),
+            },
+            headers={"hx-request": "true"},
+        )
+
+        assert response.status_code == HTTPStatus.OK
+        # Create Code action remains available alongside the active code
+        assert b"Create Code" in response.content
 
     def test_invalidate_permanent_code_success(self):
         """Test successful permanent code invalidation."""

--- a/re_sharing/organizations/views.py
+++ b/re_sharing/organizations/views.py
@@ -226,7 +226,10 @@ def manager_permanent_code_action_view(request, organization_slug):
 
     try:
         if action == "create":
-            create_permanent_code_for_organization(organization_slug, request.user)
+            name = request.POST.get("name", "")
+            create_permanent_code_for_organization(
+                organization_slug, request.user, name=name
+            )
 
         elif action == "invalidate":
             permanent_code_id = request.POST.get("permanent_code_id")

--- a/re_sharing/resources/services_permanent_code.py
+++ b/re_sharing/resources/services_permanent_code.py
@@ -4,11 +4,8 @@ import random
 from datetime import datetime
 from datetime import timedelta
 
-from django.core.exceptions import ValidationError
-from django.db.models import Q
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
-from django.utils.translation import gettext_lazy as _
 
 from re_sharing.organizations.mails import send_permanent_code_created_email
 from re_sharing.organizations.mails import send_permanent_code_renewed_email
@@ -27,35 +24,20 @@ def _generate_permanent_code() -> str:
 
 
 def create_permanent_code_for_organization(
-    organization_slug: str, created_by
+    organization_slug: str, created_by, name: str = ""
 ) -> PermanentCode:
     """Create a new permanent code for an organization.
 
     Args:
         organization_slug: The organization slug
         created_by: The user creating the code (for audit)
+        name: Optional custom name for the code. Falls back to a default
+            derived from the organization name when blank.
 
     Returns:
         The created PermanentCode instance
-
-    Raises:
-        ValidationError: If organization already has an active permanent code
     """
     organization = get_object_or_404(Organization, slug=organization_slug)
-
-    # Check if organization already has an active permanent code
-    existing_code = (
-        PermanentCode.objects.filter(organization=organization)
-        .filter(validity_start__lte=timezone.now())
-        .filter(Q(validity_end__isnull=True) | Q(validity_end__gte=timezone.now()))
-        .first()
-    )
-
-    if existing_code:
-        raise ValidationError(
-            _("Organization already has an active permanent code: %(code)s")
-            % {"code": existing_code.code}
-        )
 
     # Generate new code
     code = _generate_permanent_code()
@@ -63,13 +45,16 @@ def create_permanent_code_for_organization(
     # Get accesses 1, 2, 8
     accesses = Access.objects.filter(id__in=[1, 2, 8])
 
+    # Use the provided name, falling back to a default derived from the org
+    code_name = name.strip() or f"Permanent code for {organization.name}"
+
     # Create permanent code
     permanent_code = PermanentCode.objects.create(
         code=code,
         organization=organization,
         validity_start=timezone.now(),
         validity_end=None,  # No expiration by default
-        name=f"Permanent code for {organization.name}",
+        name=code_name,
     )
     permanent_code.accesses.set(accesses)
     permanent_code.save()

--- a/re_sharing/resources/tests/test_services_permanent_code.py
+++ b/re_sharing/resources/tests/test_services_permanent_code.py
@@ -3,8 +3,6 @@
 from datetime import timedelta
 from unittest.mock import patch
 
-import pytest
-from django.core.exceptions import ValidationError
 from django.test import TestCase
 from django.utils import timezone
 
@@ -58,23 +56,69 @@ class TestCreatePermanentCode(TestCase):
         mock_email.enqueue.assert_called_once_with(permanent_code.id)
 
     @patch("re_sharing.resources.services_permanent_code._generate_permanent_code")
-    def test_create_permanent_code_fails_when_active_code_exists(
-        self, mock_generate_code
+    @patch(
+        "re_sharing.resources.services_permanent_code.send_permanent_code_created_email"
+    )
+    def test_create_additional_permanent_code_when_active_code_exists(
+        self, mock_email, mock_generate_code
     ):
-        """Test that creating a code fails when an active code exists."""
+        """Test that an additional code is created when an active code exists."""
+        mock_generate_code.return_value = "654321"
+
         # Create an existing active permanent code
-        PermanentCodeFactory(
+        existing_code = PermanentCodeFactory(
             organization=self.organization,
+            code="111111",
             validity_start=timezone.now() - timedelta(days=1),
             validity_end=None,
             accesses=[self.access1],
         )
 
-        # Attempt to create another code should fail
-        with pytest.raises(ValidationError) as context:
-            create_permanent_code_for_organization(self.organization.slug, self.user)
+        # Creating another code succeeds and leaves the existing one untouched
+        new_code = create_permanent_code_for_organization(
+            self.organization.slug, self.user
+        )
 
-        assert "already has an active permanent code" in str(context.value)
+        assert new_code.code == "654321"
+        assert (
+            PermanentCode.objects.filter(organization=self.organization).count() == 2  # noqa: PLR2004
+        )
+
+        existing_code.refresh_from_db()
+        assert existing_code.validity_end is None
+        assert existing_code.code == "111111"
+
+    @patch("re_sharing.resources.services_permanent_code._generate_permanent_code")
+    @patch(
+        "re_sharing.resources.services_permanent_code.send_permanent_code_created_email"
+    )
+    def test_create_permanent_code_with_custom_name(
+        self, mock_email, mock_generate_code
+    ):
+        """Test that a provided name is used for the new code."""
+        mock_generate_code.return_value = "345678"
+
+        permanent_code = create_permanent_code_for_organization(
+            self.organization.slug, self.user, name="Reception key"
+        )
+
+        assert permanent_code.name == "Reception key"
+
+    @patch("re_sharing.resources.services_permanent_code._generate_permanent_code")
+    @patch(
+        "re_sharing.resources.services_permanent_code.send_permanent_code_created_email"
+    )
+    def test_create_permanent_code_blank_name_uses_default(
+        self, mock_email, mock_generate_code
+    ):
+        """Test that a blank name falls back to the default derived name."""
+        mock_generate_code.return_value = "456789"
+
+        permanent_code = create_permanent_code_for_organization(
+            self.organization.slug, self.user, name="   "
+        )
+
+        assert permanent_code.name == f"Permanent code for {self.organization.name}"
 
     @patch("re_sharing.resources.services_permanent_code._generate_permanent_code")
     def test_create_permanent_code_succeeds_when_previous_code_expired(

--- a/re_sharing/templates/organizations/manager_list_organizations.html
+++ b/re_sharing/templates/organizations/manager_list_organizations.html
@@ -152,23 +152,22 @@
       {% endif %}
     </button>
     <ul class="dropdown-menu">
-      {% if not organization.active_codes %}
-        {# Create action - only show when no code exists #}
+      {# Create action - always available; an organization may have multiple codes #}
+      <li>
+        <a href="#"
+           class="dropdown-item"
+           data-bs-toggle="modal"
+           data-bs-target="#createCodeModal-{{ organization.slug }}">
+          <svg width="1em" height="1em" class="me-1">
+            <use href="#bi-plus-lg" />
+          </svg>
+          {% trans "Create Code" %}
+        </a>
+      </li>
+      {% if organization.active_codes %}
         <li>
-          <a href="#"
-             class="dropdown-item"
-             hx-post="{% url 'organizations:manager-permanent-code-action' organization_slug=organization.slug %}"
-             hx-vals='{"action": "create"}'
-             hx-target="#tr-{{ organization.slug }}"
-             hx-swap="innerHTML"
-             hx-confirm="{% trans 'Create a new permanent code for this organization?' %}">
-            <svg width="1em" height="1em" class="me-1">
-              <use href="#bi-plus-lg" />
-            </svg>
-            {% trans "Create Code" %}
-          </a>
+          <hr class="dropdown-divider" />
         </li>
-      {% else %}
         {# Invalidate and Renew actions - show for each active code #}
         {% for code in organization.active_codes %}
           <li>
@@ -209,6 +208,52 @@
         {% endfor %}
       {% endif %}
     </ul>
+  </div>
+  {# Modal for Create action - one per organization #}
+  <div class="modal fade"
+       id="createCodeModal-{{ organization.slug }}"
+       tabindex="-1"
+       aria-labelledby="createCodeModalLabel-{{ organization.slug }}"
+       aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="createCodeModalLabel-{{ organization.slug }}">{% trans "Create Permanent Code" %}</h5>
+          <button type="button"
+                  class="btn-close"
+                  data-bs-dismiss="modal"
+                  aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          {% if organization.active_codes %}
+            <div class="alert alert-warning" role="alert">
+              {% trans "This organization already has an active permanent code. A new one will be created in addition." %}
+            </div>
+          {% endif %}
+          <form id="createCodeForm-{{ organization.slug }}">
+            <div class="mb-3">
+              <label for="code_name-{{ organization.slug }}" class="form-label">{% trans "Name" %}</label>
+              <input type="text"
+                     class="form-control"
+                     id="code_name-{{ organization.slug }}"
+                     name="name"
+                     maxlength="256" />
+              <div class="form-text">{% trans "Leave empty to use a default name." %}</div>
+            </div>
+          </form>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{% trans "Cancel" %}</button>
+          <button type="button"
+                  class="btn btn-primary"
+                  hx-post="{% url 'organizations:manager-permanent-code-action' organization_slug=organization.slug %}"
+                  hx-vals='js:{"action": "create", "name": document.getElementById("code_name-{{ organization.slug }}").value}'
+                  hx-target="#tr-{{ organization.slug }}"
+                  hx-swap="innerHTML"
+                  data-bs-dismiss="modal">{% trans "Create Code" %}</button>
+        </div>
+      </div>
+    </div>
   </div>
   {# Modals for Invalidate action - one per code #}
   {% for code in organization.active_codes %}


### PR DESCRIPTION

Managers can now create a permanent code at /organizations/manage-organizations/ even when the organization already has an active one, and can give the new code an optional name.

- remove the service-level guard that blocked creating a code when an active one exists; an organization may now hold multiple active codes
- add an optional `name` argument to create_permanent_code_for_organization, falling back to the default derived name when blank
- replace the "Create Code" confirm with a per-organization modal containing an optional name input and an active-code warning, submitted via HTMX
- update service- and view-level tests for the new behavior

Includes the OpenSpec organization-permanent-codes capability spec.